### PR TITLE
update Dockerfile to not use :onbuild + describe the repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM adaliszk/valheim-server:onbuild
+FROM adaliszk/valheim-server:vanilla
 
+ENV UID="1029" GID="65538"
 
+USER root
 
-RUN addgroup --gid 65538 custom && adduser --uid 1029 --shell /bin/bash -G custom -S custom \
-  && chown 1029:65538 /scripts /config /server /backup /data /logs
+RUN addgroup --gid "${GID}" custom && adduser --uid "${UID}" --shell /bin/bash -G custom -S custom \
+ && chown "${UID}:${GID}" /scripts /config /server /backup /data /logs
 
-USER 1029
+USER "${UID}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# SpiderKraken's Valheim-Server
+
+Just a simple build on top of [adaliszk/valheim-server](https://github.com/adaliszk/valheim-server) so it could be deployed into a Synology NAS
+with the correct User and Group. If you need this for your own, feel free to copy this example and update it with your own user and group ids.


### PR DESCRIPTION
Just a little update to use the more up-to-date `:vanilla` tag (or any other if you decide to go with modded one). This should work just fine while allowing you to have the custom User and Group that Synology needs.